### PR TITLE
Add: Export song lists as text file

### DIFF
--- a/GHTCP-cleaned.csproj
+++ b/GHTCP-cleaned.csproj
@@ -61,8 +61,10 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.DirectX.DirectSound" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AVTools.MpegUtils\FFMpegException.cs" />
@@ -666,6 +668,12 @@
     <Compile Include="ns15\SongProperties.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="ns15\SortSongListForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ns15\SortSongListForm.Designer.cs">
+      <DependentUpon>SortSongListForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="ns15\TierManagement.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1109,6 +1117,9 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="ns15\SongProperties.resources" />
+    <EmbeddedResource Include="ns15\SortSongListForm.resx">
+      <DependentUpon>SortSongListForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ns15\TierManagement.resources" />
     <EmbeddedResource Include="ns16\ActionsWindow.resources" />
     <EmbeddedResource Include="ns17\About.resources" />

--- a/ns15/MainMenu.cs
+++ b/ns15/MainMenu.cs
@@ -4553,6 +4553,11 @@ namespace ns15
 
         private void exportSongListToolStripMenuItem1_Click(object sender, EventArgs e)
         {
+            SortSongListForm form = new SortSongListForm();
+            form.ShowDialog();
+
+            bool sortBySetlist = form.sortBy == SortSongListForm.SortBy.Setlist;
+
             SaveFileDialog saveFileDlg = new SaveFileDialog();
             saveFileDlg.Filter = "txt files (*.txt)|*.txt";
             saveFileDlg.Title = "Please select where you would like to save the song list.";
@@ -4561,11 +4566,6 @@ namespace ns15
             {
                 return;
             }
-
-            SortSongListForm form = new SortSongListForm();
-            form.ShowDialog();
-
-            bool sortBySetlist = form.sortBy == SortSongListForm.SortBy.Setlist;
 
             // Open selected file for writing
             using (Stream myStream = saveFileDlg.OpenFile())

--- a/ns15/MainMenu.cs
+++ b/ns15/MainMenu.cs
@@ -2056,6 +2056,7 @@ namespace ns15
             this.SaveChart_MenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportSetlistAsChartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportSongListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportSongListToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.Exit_MenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.Add_MenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -2185,7 +2186,6 @@ namespace ns15
             this.MainContainer = new System.Windows.Forms.ToolStripContainer();
             this.StatusStrip = new System.Windows.Forms.StatusStrip();
             this.ToolStripStatusLbl = new System.Windows.Forms.ToolStripStatusLabel();
-            this.exportSongListToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.rightClickMenu.SuspendLayout();
             this.TopMenuStrip.SuspendLayout();
             this.SidePanel.SuspendLayout();
@@ -2406,9 +2406,18 @@ namespace ns15
             this.exportSongListToolStripMenuItem.Enabled = false;
             this.exportSongListToolStripMenuItem.Name = "exportSongListToolStripMenuItem";
             this.exportSongListToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
-            this.exportSongListToolStripMenuItem.Text = "Export Setlist Song List";
-            this.exportSongListToolStripMenuItem.ToolTipText = "Export songs in the selected setlist as text file";
+            this.exportSongListToolStripMenuItem.Text = "Export Setlist as CSV";
+            this.exportSongListToolStripMenuItem.ToolTipText = "Export songs in the selected setlist as CSV";
             this.exportSongListToolStripMenuItem.Click += new System.EventHandler(this.exportSongListToolStripMenuItem_Click);
+            // 
+            // exportSongListToolStripMenuItem1
+            // 
+            this.exportSongListToolStripMenuItem1.Enabled = false;
+            this.exportSongListToolStripMenuItem1.Name = "exportSongListToolStripMenuItem1";
+            this.exportSongListToolStripMenuItem1.Size = new System.Drawing.Size(264, 22);
+            this.exportSongListToolStripMenuItem1.Text = "Export Songlist as CSV";
+            this.exportSongListToolStripMenuItem1.ToolTipText = "Export the whole songlist as CSV";
+            this.exportSongListToolStripMenuItem1.Click += new System.EventHandler(this.exportSongListToolStripMenuItem1_Click);
             // 
             // toolStripSeparator6
             // 
@@ -3728,14 +3737,7 @@ namespace ns15
             this.ToolStripStatusLbl.Size = new System.Drawing.Size(0, 17);
             this.ToolStripStatusLbl.Tag = "Function Description";
             // 
-            // exportSongListToolStripMenuItem1
             // 
-            this.exportSongListToolStripMenuItem1.Enabled = false;
-            this.exportSongListToolStripMenuItem1.Name = "exportSongListToolStripMenuItem1";
-            this.exportSongListToolStripMenuItem1.Size = new System.Drawing.Size(264, 22);
-            this.exportSongListToolStripMenuItem1.Text = "Export Song List";
-            this.exportSongListToolStripMenuItem1.ToolTipText = "Export the whole song list as text file";
-            this.exportSongListToolStripMenuItem1.Click += new System.EventHandler(this.exportSongListToolStripMenuItem1_Click);
             // MainMenu
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -4507,9 +4509,9 @@ namespace ns15
             if (this.gh3Songlist_0.gh3SetlistList.ContainsKey(this.int_0))
             {
                 SaveFileDialog saveFileDlg = new SaveFileDialog();
-                saveFileDlg.Filter = "txt files (*.txt)|*.txt";
-                saveFileDlg.Title = "Please select where you would like to save the song list.";
-                saveFileDlg.FileName = String.Format("{0}.txt", this.Setlist_DropBox.Text);
+                saveFileDlg.Filter = "CSV files (*.csv)|*.csv";
+                saveFileDlg.Title = "Please select where you would like to save the songlist";
+                saveFileDlg.FileName = String.Format("{0}.csv", this.Setlist_DropBox.Text);
                 if (saveFileDlg.ShowDialog() != DialogResult.OK)
                 {
                     return;
@@ -4539,10 +4541,13 @@ namespace ns15
 
                     // Write to file
                     using (StreamWriter outFile = new StreamWriter(myStream))
-                    {                        
+                    {
+                        // Write CSV header
+                        outFile.WriteLine("\"artist\",\"song\"");
                         foreach (GH3Song song in songs)
                         {
-                            outFile.WriteLine(String.Format("{0} - {1}", song.artist, song.title));
+                            outFile.WriteLine(String.Format("\"{0}\",\"{1}\"", song.artist.Replace("\"", "\"\""), 
+                                                                               song.title.Replace("\"", "\"\"")));
                         }
                     }
                 }
@@ -4559,9 +4564,9 @@ namespace ns15
             bool sortBySetlist = form.sortBy == SortSongListForm.SortBy.Setlist;
 
             SaveFileDialog saveFileDlg = new SaveFileDialog();
-            saveFileDlg.Filter = "txt files (*.txt)|*.txt";
-            saveFileDlg.Title = "Please select where you would like to save the song list.";
-            saveFileDlg.FileName = "songlist.txt";
+            saveFileDlg.Filter = "CSV files (*.csv)|*.csv";
+            saveFileDlg.Title = "Please select where you would like to save the songlist";
+            saveFileDlg.FileName = "songlist.csv";
             if (saveFileDlg.ShowDialog() != DialogResult.OK)
             {
                 return;
@@ -4603,16 +4608,13 @@ namespace ns15
                 // Write results to file
                 using (StreamWriter outFile = new StreamWriter(myStream))
                 {
+                    // Write CSV header
+                    outFile.WriteLine("\"artist\",\"song\",\"setlist\"");
                     foreach (KeyValuePair<string, GH3Song> song in songs)
                     {
-                        if (sortBySetlist)
-                        {
-                            outFile.WriteLine(String.Format("{0}: {1} - {2}", song.Key, song.Value.artist, song.Value.title));
-                        }
-                        else
-                        {
-                            outFile.WriteLine(String.Format("{1} - {2} ({0})", song.Key, song.Value.artist, song.Value.title));
-                        }
+                        outFile.WriteLine(String.Format("\"{1}\",\"{2}\",\"{0}\"", song.Key.Replace("\"", "\"\""), 
+                                                                                   song.Value.artist.Replace("\"", "\"\""), 
+                                                                                   song.Value.title.Replace("\"", "\"\"")));
                     }
                 }
             }

--- a/ns15/MainMenu.cs
+++ b/ns15/MainMenu.cs
@@ -482,6 +482,8 @@ namespace ns15
 			}
 		};
         private IContainer components;
+        private ToolStripMenuItem exportSongListToolStripMenuItem;
+        private ToolStripMenuItem exportSongListToolStripMenuItem1;
         private int[][] int_2 = new int[][]
 		{
 			new int[]
@@ -2052,6 +2054,7 @@ namespace ns15
             this.SaveSGH_MenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.SaveChart_MenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportSetlistAsChartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportSongListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.Exit_MenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.Add_MenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -2181,6 +2184,7 @@ namespace ns15
             this.MainContainer = new System.Windows.Forms.ToolStripContainer();
             this.StatusStrip = new System.Windows.Forms.StatusStrip();
             this.ToolStripStatusLbl = new System.Windows.Forms.ToolStripStatusLabel();
+            this.exportSongListToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.rightClickMenu.SuspendLayout();
             this.TopMenuStrip.SuspendLayout();
             this.SidePanel.SuspendLayout();
@@ -2308,6 +2312,8 @@ namespace ns15
             this.SaveSGH_MenuItem,
             this.SaveChart_MenuItem,
             this.exportSetlistAsChartsToolStripMenuItem,
+            this.exportSongListToolStripMenuItem,
+            this.exportSongListToolStripMenuItem1,
             this.toolStripSeparator6,
             this.Exit_MenuItem});
             this.File_MenuItem.Name = "File_MenuItem";
@@ -2393,6 +2399,15 @@ namespace ns15
             this.exportSetlistAsChartsToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
             this.exportSetlistAsChartsToolStripMenuItem.Text = "Export Setlist as Charts";
             this.exportSetlistAsChartsToolStripMenuItem.Click += new System.EventHandler(this.exportSetlistAsChartsToolStripMenuItem_Click_1);
+            // 
+            // exportSongListToolStripMenuItem
+            // 
+            this.exportSongListToolStripMenuItem.Enabled = false;
+            this.exportSongListToolStripMenuItem.Name = "exportSongListToolStripMenuItem";
+            this.exportSongListToolStripMenuItem.Size = new System.Drawing.Size(264, 22);
+            this.exportSongListToolStripMenuItem.Text = "Export Setlist Song List";
+            this.exportSongListToolStripMenuItem.ToolTipText = "Export songs in the selected setlist as text file";
+            this.exportSongListToolStripMenuItem.Click += new System.EventHandler(this.exportSongListToolStripMenuItem_Click);
             // 
             // toolStripSeparator6
             // 
@@ -3712,6 +3727,14 @@ namespace ns15
             this.ToolStripStatusLbl.Size = new System.Drawing.Size(0, 17);
             this.ToolStripStatusLbl.Tag = "Function Description";
             // 
+            // exportSongListToolStripMenuItem1
+            // 
+            this.exportSongListToolStripMenuItem1.Enabled = false;
+            this.exportSongListToolStripMenuItem1.Name = "exportSongListToolStripMenuItem1";
+            this.exportSongListToolStripMenuItem1.Size = new System.Drawing.Size(264, 22);
+            this.exportSongListToolStripMenuItem1.Text = "Export Song List";
+            this.exportSongListToolStripMenuItem1.ToolTipText = "Export the whole song list as text file";
+            this.exportSongListToolStripMenuItem1.Click += new System.EventHandler(this.exportSongListToolStripMenuItem1_Click);
             // MainMenu
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -3790,7 +3813,7 @@ namespace ns15
 			ToolStripItem arg_84_0 = this.SaveSGH_MenuItem;
             ToolStripItem export = this.exportSetlistAsChartsToolStripMenuItem;
             ToolStripItem arg_7B_0 = this.SaveTGH_MenuItem;
-			Control arg_73_0 = this.SetlistStrip;
+            Control arg_73_0 = this.SetlistStrip;
 			Control arg_6B_0 = this.SetlistConf_TLPanel;
 			this.GH3Folder_MenuItem.Enabled = bool_1;
 			arg_6B_0.Enabled = bool_1;
@@ -3803,7 +3826,10 @@ namespace ns15
 			arg_AC_0.Enabled = bool_1;
 			arg_B3_0.Enabled = bool_1;
             export.Enabled = bool_1;
-		}
+            this.exportSongListToolStripMenuItem.Enabled = bool_1;
+            this.exportSongListToolStripMenuItem1.Enabled = bool_1;
+
+        }
 
 		public void method_13()
 		{
@@ -4473,6 +4499,102 @@ namespace ns15
         private void forceRB3MidConversionToolStripMenuItem_Click(object sender, EventArgs e)
         {
 
+        }
+
+        private void exportSongListToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (this.gh3Songlist_0.gh3SetlistList.ContainsKey(this.int_0))
+            {
+                SaveFileDialog saveFileDlg = new SaveFileDialog();
+                saveFileDlg.Filter = "txt files (*.txt)|*.txt";
+                saveFileDlg.Title = "Please select where you would like to save the song list.";
+                saveFileDlg.FileName = String.Format("{0}.txt", this.Setlist_DropBox.Text);
+                if (saveFileDlg.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+                // Open selected file for writing
+                using (Stream myStream = saveFileDlg.OpenFile())
+                {
+                    if (myStream == null)
+                    {
+                        MessageBox.Show("Couldn't open file for writing");
+                        return;
+                    }
+
+                    using (StreamWriter outFile = new StreamWriter(myStream))
+                    {
+                        List<GH3Song> songs = new List<GH3Song>();
+                        foreach (GH3Tier tier in this.gh3Songlist_0.gh3SetlistList[this.int_0].tiers)
+                        {
+                            foreach (GH3Song song in tier.songs)
+                            {
+                                songs.Add(song);
+                            }
+                        }
+                        songs.Sort(delegate (GH3Song lhs, GH3Song rhs)
+                        {
+                            return String.Format("{0} - {1}", lhs.artist, lhs.title).CompareTo(String.Format("{0} - {1}", rhs.artist, rhs.title));
+                        });
+                        foreach (GH3Song song in songs)
+                        {
+                            outFile.WriteLine(String.Format("{0} - {1}", song.artist, song.title));
+                        }
+                    }
+                }
+
+                MessageBox.Show("Done.");
+            }
+        }
+
+        private void exportSongListToolStripMenuItem1_Click(object sender, EventArgs e)
+        {
+            SaveFileDialog saveFileDlg = new SaveFileDialog();
+            saveFileDlg.Filter = "txt files (*.txt)|*.txt";
+            saveFileDlg.Title = "Please select where you would like to save the song list.";
+            saveFileDlg.FileName = "songlist.txt";
+            if (saveFileDlg.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            // Open selected file for writing
+            using (Stream myStream = saveFileDlg.OpenFile())
+            {
+                if (myStream == null)
+                {
+                    MessageBox.Show("Couldn't open file for writing");
+                    return;
+                }
+
+                using (StreamWriter outFile = new StreamWriter(myStream))
+                {
+                    // setlist contains a pair of setlist name => setlist id
+                    foreach (KeyValuePair<string, int> setlist in this.gh3Songlist_0.class214_0)
+                    {
+                        List<GH3Song> songs = new List<GH3Song>();                        
+                        foreach (GH3Tier tier in this.gh3Songlist_0.gh3SetlistList[this.int_0 = this.gh3Songlist_0.method_9(setlist.Key)].tiers)
+                        {
+                            foreach (GH3Song song in tier.songs)
+                            {
+                                songs.Add(song);
+                            }
+                        }
+                        songs.Sort(delegate (GH3Song lhs, GH3Song rhs)
+                        {
+                            return String.Format("{0} - {1}", lhs.artist, lhs.title).CompareTo(String.Format("{0} - {1}", rhs.artist, rhs.title));
+                        });
+                        foreach (GH3Song song in songs)
+                        {
+                            outFile.WriteLine(String.Format("{0}: {1} - {2}", setlist.Key, song.artist, song.title));
+                        }
+                    }
+
+                }
+            }
+
+            MessageBox.Show("Done.");
         }
     }
 }

--- a/ns15/MainMenu.cs
+++ b/ns15/MainMenu.cs
@@ -4524,20 +4524,22 @@ namespace ns15
                         return;
                     }
 
-                    using (StreamWriter outFile = new StreamWriter(myStream))
+                    // Get songs for this setlist
+                    List<GH3Song> songs = new List<GH3Song>();
+                    foreach (GH3Tier tier in this.gh3Songlist_0.gh3SetlistList[this.int_0].tiers)
                     {
-                        List<GH3Song> songs = new List<GH3Song>();
-                        foreach (GH3Tier tier in this.gh3Songlist_0.gh3SetlistList[this.int_0].tiers)
+                        foreach (GH3Song song in tier.songs)
                         {
-                            foreach (GH3Song song in tier.songs)
-                            {
-                                songs.Add(song);
-                            }
+                            songs.Add(song);
                         }
-                        songs.Sort(delegate (GH3Song lhs, GH3Song rhs)
-                        {
-                            return String.Format("{0} - {1}", lhs.artist, lhs.title).CompareTo(String.Format("{0} - {1}", rhs.artist, rhs.title));
-                        });
+                    }
+
+                    // Sort songs by artist and title
+                    songs = songs.OrderBy(song => song.artist).ThenBy(song => song.title).ToList();
+
+                    // Write to file
+                    using (StreamWriter outFile = new StreamWriter(myStream))
+                    {                        
                         foreach (GH3Song song in songs)
                         {
                             outFile.WriteLine(String.Format("{0} - {1}", song.artist, song.title));

--- a/ns15/SortSongListForm.Designer.cs
+++ b/ns15/SortSongListForm.Designer.cs
@@ -1,0 +1,73 @@
+﻿namespace ns15
+{
+    partial class SortSongListForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(38, 38);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(150, 23);
+            this.button1.TabIndex = 0;
+            this.button1.Text = "Sort by Setlist";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click_1);
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(209, 38);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(150, 23);
+            this.button2.TabIndex = 1;
+            this.button2.Text = "Sort by Artist";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.button2_Click);
+            // 
+            // SortSongListForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(398, 101);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.button1);
+            this.Name = "SortSongListForm";
+            this.Text = "Sort Song List";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button button2;
+    }
+}

--- a/ns15/SortSongListForm.cs
+++ b/ns15/SortSongListForm.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace ns15
+{
+    public partial class SortSongListForm : Form
+    {
+        public enum SortBy
+        {
+            Setlist,
+            Artist
+        };
+        public SortBy sortBy;
+
+        public SortSongListForm()
+        {
+            InitializeComponent();
+        }
+
+        private void button1_Click_1(object sender, EventArgs e)
+        {
+            sortBy = SortBy.Setlist;
+            this.Close();
+        }
+
+        private void button2_Click(object sender, EventArgs e)
+        {
+            sortBy = SortBy.Artist;
+            this.Close();
+        }
+    }
+}

--- a/ns15/SortSongListForm.resx
+++ b/ns15/SortSongListForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
This commit adds two items under "File" menu:

"Export Setlist Song List" and "Export Song List".

The first will export all the songs in the selected setlist as text file in the following format: Artist - Title
The second will export all the songs in the game as text file in the following format: Setlist: Artist - Title

These features will be especially useful for streamers. E.g. on ukog's streams quite often someone requests a song but neither ukog nor the requester knows what setlist the song is on. With this the streamer can export the song list and provide the song list to viewers. Then the viewers see what songs the streamer has and both can tell what setlist the song is on.

I hope the code is good. It's the only C# I've ever written.

edit: You can now sort whole song list by artist as well, so the format is: Artist - Title (Setlist)